### PR TITLE
added first version of the no-go area routing.

### DIFF
--- a/sql/overwrite_cost.sql
+++ b/sql/overwrite_cost.sql
@@ -8,48 +8,62 @@ it will make it crash.  If it is the former, great for us because then we wouldn
 "final check".
 */
 
--- DROP FUNCTION replace_cost(integer);
+--DROP FUNCTION replace_cost(GEOMETRY);
 
 CREATE OR REPLACE FUNCTION replace_cost(
-    test_input INTEGER
+    in_geom GEOMETRY
 )
 
 	RETURNS TABLE(
-		class_id INTEGER,
+		gid BIGINT,
 		name VARCHAR(255),
 		cost_s DOUBLE PRECISION,
 		reverse_cost_s DOUBLE PRECISION
 	) AS
 
-	$BODY$
+	$$
 		SELECT
-			a.class_id AS class_id,
+			a.gid AS gid,
 			a.name AS name,
 			a.cost_s AS cost_s,
 			a.reverse_cost_s AS reverse_cost_s
 		FROM
 			ways AS a
 		WHERE 
-			a.class_id != test_input
+			NOT ST_Intersects(in_geom, a.the_geom)
 
 		UNION ALL
 
 		SELECT
-			a.class_id AS class_id,
+			a.gid AS gid,
 			a.name AS name,
 			'INFINITY' AS cost_s,
 			'INFINITY' AS reverse_cost_s
 		FROM
 			ways AS a
 		WHERE 
-			a.class_id = test_input
+			ST_Intersects(in_geom, a.the_geom)
 
 		ORDER BY
-			name
+			cost_s
+		DESC
 
-	$BODY$
+	$$
 
 	LANGUAGE SQL;
 
+ /* https://gis.stackexchange.com/questions/262474/pass-geometry-as-input-to-custom-postgis-function/262501
+ http://www.postgresonline.com/journal/archives/201-Using-RETURNS-TABLE-vs.-OUT-parameters.html */
 
-SELECT * FROM replace_cost(112);
+SELECT (
+	replace_cost(
+		ST_GeomFromText(
+			'MULTIPOLYGON(((8.40226615336606 49.0079797109504,8.40234579778452 49.0104885101318,8.40676606300897 49.0103823175739,8.40668641859051 49.0078735183924,8.40668641859051 49.0078735183924,8.40226615336606 49.0079797109504)))', 4326
+		)
+	)
+).*
+
+
+
+
+

--- a/sql/overwrite_cost_joined.sql
+++ b/sql/overwrite_cost_joined.sql
@@ -1,0 +1,88 @@
+﻿--DROP FUNCTION replace_cost(GEOMETRY);
+
+CREATE OR REPLACE FUNCTION replace_cost(
+    in_geom GEOMETRY
+)
+
+	RETURNS TABLE(
+		gid BIGINT,
+		name VARCHAR(255),
+		cost_s DOUBLE PRECISION,
+		reverse_cost_s DOUBLE PRECISION
+	) AS
+
+	$$
+
+		SELECT
+			gid AS gid,
+			name AS name,
+			cost_s AS cost_s,
+			reverse_cost_s AS reverse_cost_s
+		FROM
+			ways
+		WHERE 
+			NOT ST_Intersects(in_geom, the_geom)
+
+		UNION ALL
+
+		SELECT
+			gid AS gid,
+			name AS name,
+			'INFINITY' AS cost_s,
+			'INFINITY' AS reverse_cost_s
+		FROM
+			ways
+		WHERE 
+			ST_Intersects(in_geom, the_geom)
+
+	$$
+
+	LANGUAGE SQL;
+
+ /* https://gis.stackexchange.com/questions/262474/pass-geometry-as-input-to-custom-postgis-function/262501
+ http://www.postgresonline.com/journal/archives/201-Using-RETURNS-TABLE-vs.-OUT-parameters.html */
+
+/*
+							WITHOUT NOGO:
+*/
+/* SELECT edge FROM pgr_dijkstra(
+	'
+	SELECT
+		ways.gid AS id,
+		ways.source AS source,
+		ways.target AS target,
+		ways.cost_s AS cost,
+		ways.reverse_cost_s AS reverse_cost
+	FROM
+		ways
+	',
+	51982,
+	5656
+) */
+
+/*
+							WITH NOGO:
+*/
+SELECT edge FROM pgr_dijkstra(
+	'
+	SELECT
+		ways.gid AS id,
+		ways.source AS source,
+		ways.target AS target,
+		cost_replacement.cost_s AS cost,
+		cost_replacement.reverse_cost_s AS reverse_cost
+	FROM
+		ways
+	JOIN
+		( SELECT * FROM 
+			replace_cost(
+				ST_GeomFromText(
+					''MULTIPOLYGON(((8.40226615336606 49.0079797109504,8.40234579778452 49.0104885101318,8.40676606300897 49.0103823175739,8.40668641859051 49.0078735183924,8.40668641859051 49.0078735183924,8.40226615336606 49.0079797109504)))'', 4326
+				)
+			)
+		) AS cost_replacement
+	ON
+		ways.gid = cost_replacement.gid;
+	',
+	51982,
+	5656);


### PR DESCRIPTION
the first version of the no-go area routing using the dijkstra algorithm.  still needs rigorous testing of edge cases.  must also be encapsulated into standalone function like pgr_nogo_dijsktra() or something.  then we need to do the same for all the various routing algorithms supported by pgr